### PR TITLE
avoid passing path that contains query string to Committee::Drivers::OpenApi3::Schema#operation_object

### DIFF
--- a/lib/committee/rails/request_object.rb
+++ b/lib/committee/rails/request_object.rb
@@ -9,11 +9,11 @@ module Committee::Rails
     end
 
     def path
-      @request.original_fullpath
+      URI.parse(@request.original_fullpath).path
     end
 
     def path_info
-      @request.original_fullpath
+      URI.parse(@request.original_fullpath).path
     end
 
     def request_method


### PR DESCRIPTION
if passing path that contains query stirng to `Committee::Drivers::OpenApi3::Schema#operation_object`, always return nil.
`integration_session.request#path` and `integration_session.request#path_info` returns path without query string.
`RequestObject#path` and `RequestObject#path_info` respect this behavior.